### PR TITLE
[GET] 강의 목록 가져오기 API 구현

### DIFF
--- a/functions/api/routes/lectures/getLecturesGET.js
+++ b/functions/api/routes/lectures/getLecturesGET.js
@@ -44,7 +44,7 @@ module.exports = async (req, res) => {
             lectures.sort(lecture => -lecture.tags.length)
         }
 
-        res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_REQUEST_RANK_SUCCESS, lectures));
+        res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_LECTURES_SUCCESS, lectures));
     } catch (error) {
         functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
         console.log(error);

--- a/functions/api/routes/lectures/getLecturesGET.js
+++ b/functions/api/routes/lectures/getLecturesGET.js
@@ -10,7 +10,7 @@ module.exports = async (req, res) => {
     const { categoryId, skillId } = req.params;
     let { ordering } = req.query;
 
-    if (ordering == undefined) {
+    if (ordering === undefined) {
         ordering = "default";
     }
     ordering = ordering.toLowerCase();

--- a/functions/api/routes/lectures/getLecturesGET.js
+++ b/functions/api/routes/lectures/getLecturesGET.js
@@ -39,6 +39,11 @@ module.exports = async (req, res) => {
                 break;
             }
         }
+
+        if (!order.column) {
+            lectures.sort(lecture => lecture.tags.length)
+        }
+
         res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_REQUEST_RANK_SUCCESS, lectures));
     } catch (error) {
         functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);

--- a/functions/api/routes/lectures/getLecturesGET.js
+++ b/functions/api/routes/lectures/getLecturesGET.js
@@ -1,0 +1,50 @@
+const functions = require('firebase-functions');
+const util = require('../../../lib/util');
+const statusCode = require('../../../constants/statusCode');
+const responseMessage = require('../../../constants/responseMessage');
+const db = require('../../../db/db');
+const { lectureDB, orderingDB } = require('../../../db');
+
+module.exports = async (req, res) => {
+    let client;
+    const { categoryId, skillId } = req.params;
+    let { ordering } = req.query;
+
+    if (ordering == undefined) {
+        ordering = "default";
+    }
+    ordering = ordering.toLowerCase();
+    if (!(["fast", "slow", "price", "-price", "date", "repeat", "-repeat", "answer", "default"].includes(ordering))) {
+        return res.status(statusCode.BAD_REQUEST).send(util.fail(statusCode.BAD_REQUEST, responseMessage.OUT_OF_VALUE));
+    }
+
+    try {
+        client = await db.connect(req);
+        const order = await orderingDB.getOrder(client, ordering);
+        const lectures = await lectureDB.getLectures(client, categoryId, skillId, order)
+        let i = 1;
+        lectures[0].tags = [lectures[0].tagName];
+        delete lectures[0].tagName;
+
+        while (true) {
+            if (lectures[i].id === lectures[i - 1].id) {
+                lectures[i - 1].tags.push(lectures[i].tagName);
+                lectures.splice(i);
+            } else {
+                lectures[i].tags = [lectures[i].tagName];
+                delete lectures[i].tagName;
+                i++;
+            }
+            if (i === lectures.length) {
+                break;
+            }
+        }
+        res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_REQUEST_RANK_SUCCESS, lectures));
+    } catch (error) {
+        functions.logger.error(`[ERROR] [${req.method.toUpperCase()}] ${req.originalUrl}`, `[CONTENT] ${error}`);
+        console.log(error);
+        res.status(statusCode.INTERNAL_SERVER_ERROR).send(util.fail(statusCode.INTERNAL_SERVER_ERROR, responseMessage.INTERNAL_SERVER_ERROR));
+    } finally {
+        client.release();
+    }
+};

--- a/functions/api/routes/lectures/getLecturesGET.js
+++ b/functions/api/routes/lectures/getLecturesGET.js
@@ -29,7 +29,7 @@ module.exports = async (req, res) => {
         while (true) {
             if (lectures[i].id === lectures[i - 1].id) {
                 lectures[i - 1].tags.push(lectures[i].tagName);
-                lectures.splice(i);
+                lectures.splice(i, 1);
             } else {
                 lectures[i].tags = [lectures[i].tagName];
                 delete lectures[i].tagName;
@@ -41,7 +41,7 @@ module.exports = async (req, res) => {
         }
 
         if (!order.column) {
-            lectures.sort(lecture => lecture.tags.length)
+            lectures.sort(lecture => -lecture.tags.length)
         }
 
         res.status(statusCode.OK).send(util.success(statusCode.OK, responseMessage.READ_REQUEST_RANK_SUCCESS, lectures));

--- a/functions/api/routes/lectures/index.js
+++ b/functions/api/routes/lectures/index.js
@@ -3,5 +3,6 @@ const router = express.Router();
 
 router.post('/request', require('./requestLecturePOST'));
 router.get('/rank', require('./lectureRankGET'));
+router.get('/:categoryId/:skillId', require('./getLecturesGET'));
 
 module.exports = router;

--- a/functions/db/index.js
+++ b/functions/db/index.js
@@ -9,4 +9,5 @@ module.exports = {
   requestDB: require('./request'),
   skillDB: require('./skill'),
   tagDB: require('./tag'),
+  orderingDB: require('./ordering'),
 };

--- a/functions/db/lecture.js
+++ b/functions/db/lecture.js
@@ -1,4 +1,5 @@
 const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
+const format = require('pg-format');
 
 const getLectureTotal = async (client) => {
   const { rowCount: totalNumber } = await client.query(
@@ -26,28 +27,28 @@ const getLectures = async (client, categoryId, skillId, order) => {
   }
 
   if (order.isDesc) {
-    const { rows } = await client.query(
+    const sql = format(
       `
       SELECT l.id as id, l.name as name, price, time, start_year, duration, review_time, has_preview, has_optional, url, t.name as tag_name
       FROM lecture as l, tag_lecture as tl, tag as t, review_time as rt
       WHERE l.id = tl.lecture_id and tl.tag_id = t.id and l.review_time_id = rt.id
-      AND l.category_id = $1 and l.skill_id = $2
-      ORDER BY $3 DESC, l.name
-      `,
-      [categoryId, skillId, order.column]
-    );
+      AND l.category_id = %s and l.skill_id = %s
+      ORDER BY %I DESC, l.name
+      `, categoryId, skillId, order.column
+    )
+    const { rows } = await client.query(sql);
     return convertSnakeToCamel.keysToCamel(rows);
   } else {
-    const { rows } = await client.query(
+    const sql = format(
       `
       SELECT l.id as id, l.name as name, price, time, start_year, duration, review_time, has_preview, has_optional, url, t.name as tag_name
       FROM lecture as l, tag_lecture as tl, tag as t, review_time as rt
       WHERE l.id = tl.lecture_id and tl.tag_id = t.id and l.review_time_id = rt.id
-      AND l.category_id = $1 and l.skill_id = $2
-      ORDER BY $3, l.name
-      `,
-      [categoryId, skillId, order.column]
-    );
+      AND l.category_id = %s and l.skill_id = %s
+      ORDER BY %I, l.name
+      `, categoryId, skillId, order.column
+    )
+    const { rows } = await client.query(sql);
     return convertSnakeToCamel.keysToCamel(rows);
   }
 }

--- a/functions/db/lecture.js
+++ b/functions/db/lecture.js
@@ -10,6 +10,21 @@ const getLectureTotal = async (client) => {
 };
 
 const getLectures = async (client, categoryId, skillId, order) => {
+  if (!order.column) {
+    const { rows } = await client.query(
+      `
+      SELECT l.id as id, l.name as name, price, time, start_year, duration, review_time, has_preview, has_optional, url, t.name as tag_name
+      FROM lecture as l, tag_lecture as tl, tag as t, review_time as rt
+      WHERE l.id = tl.lecture_id and tl.tag_id = t.id and l.review_time_id = rt.id
+      AND l.category_id = $1 and l.skill_id = $2
+      ORDER BY l.name
+      `,
+      [categoryId, skillId]
+    );
+    return convertSnakeToCamel.keysToCamel(rows);
+
+  }
+
   if (order.isDesc) {
     const { rows } = await client.query(
       `

--- a/functions/db/lecture.js
+++ b/functions/db/lecture.js
@@ -1,3 +1,5 @@
+const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
+
 const getLectureTotal = async (client) => {
   const { rowCount: totalNumber } = await client.query(
     `
@@ -7,4 +9,35 @@ const getLectureTotal = async (client) => {
   return { totalNumber };
 };
 
-module.exports = { getLectureTotal };
+const getLectures = async (client, categoryId, skillId, order) => {
+  if (order.isDesc) {
+    const { rows } = await client.query(
+      `
+      SELECT l.id as id, l.name as name, price, time, start_year, duration, review_time, has_preview, has_optional, url, t.name as tag_name
+      FROM lecture as l, tag_lecture as tl, tag as t, review_time as rt
+      WHERE l.id = tl.lecture_id and tl.tag_id = t.id and l.review_time_id = rt.id
+      AND l.category_id = $1 and l.skill_id = $2
+      ORDER BY $3 DESC, l.name
+      `,
+      [categoryId, skillId, order.column]
+    );
+    return convertSnakeToCamel.keysToCamel(rows);
+  } else {
+    const { rows } = await client.query(
+      `
+      SELECT l.id as id, l.name as name, price, time, start_year, duration, review_time, has_preview, has_optional, url, t.name as tag_name
+      FROM lecture as l, tag_lecture as tl, tag as t, review_time as rt
+      WHERE l.id = tl.lecture_id and tl.tag_id = t.id and l.review_time_id = rt.id
+      AND l.category_id = $1 and l.skill_id = $2
+      ORDER BY $3, l.name
+      `,
+      [categoryId, skillId, order.column]
+    );
+    return convertSnakeToCamel.keysToCamel(rows);
+  }
+}
+
+module.exports = {
+  getLectureTotal,
+  getLectures
+};

--- a/functions/db/ordering.js
+++ b/functions/db/ordering.js
@@ -1,0 +1,17 @@
+const convertSnakeToCamel = require('../lib/convertSnakeToCamel');
+
+const getOrder = async (client, orderName) => {
+    const { rows } = await client.query(
+        `
+        SELECT * 
+        FROM ordering
+        WHERE "order" = $1
+        `,
+        [orderName]
+    );
+    return convertSnakeToCamel.keysToCamel(rows[0]);
+};
+
+module.exports = {
+    getOrder
+};

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -3341,6 +3341,11 @@
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.5.0.tgz",
       "integrity": "sha512-r5o/V/ORTA6TmUnyWZR9nCj1klXCO2CEKNRlVuJptZe85QuhFayC7WeMic7ndayT5IRIR0S0xFxFi2ousartlQ=="
     },
+    "pg-format": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/pg-format/-/pg-format-1.0.4.tgz",
+      "integrity": "sha1-J3NCNsKtP05QZJFaWTNOIAQKgo4="
+    },
     "pg-int8": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -29,6 +29,7 @@
     "lodash": "^4.17.21",
     "nodemon": "^2.0.15",
     "pg": "^8.7.1",
+    "pg-format": "^1.0.4",
     "tools": "0.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### 작업 내용
- [x] [GET] 강의 목록 가져오기 API

### 작업 설명
- 분야 id, 스킬 id 기반 강의 목록 가져오기
- ordering 쿼리를 이용하여 정렬 가능
- postman 실행 결과
![image](https://user-images.githubusercontent.com/32464833/149817016-8289fe93-9bde-4783-8544-9c6f7df3f5a8.png)


### 기타 사항
- ordering 종류는 ordering 테이블에 존재함
    - fast : 강의 시간이 빠른 순
    - slow : 강의 시간이 짧은 순
    - price : 가격이 비싼 순
    - -price : 가격이 저렴한 순
    - repeat : 강의 수강 기간이 긴 순
    - -repeat : 강의 수간 기간이 짧은 순
    - date : 강의 개설 일자 최근 순
    - answer : 질문 응답 시간 FAST-SLOW-UNKNOWN 순
    - default(ordering이 없을 때) : 태그 개수가 많은 순

- order by의 경우 prepared statement가 적용되지 않는 문제가 존재하여 pg-format 모듈 사용